### PR TITLE
easy tweening of setter/getter controlled values

### DIFF
--- a/tests/main.lua
+++ b/tests/main.lua
@@ -1,0 +1,101 @@
+Timer = require("../timer")
+
+
+function love.load()
+   -- test basic functionality
+   basic = {x=0, y=0}
+   -- test tweening for sub-table
+   inner_table = {posn={x=20, y=20}}
+   -- test tweening for array-like
+   array_like = {40, 40}
+   -- test tweening for single getter/setter
+   univar_setget = {
+      getX = function(self)
+	 return self.x
+      end,
+      getY = function(self)
+	 return self.y
+      end,
+      setX = function(self, x)
+	 self.x = x
+      end,
+      setY = function(self, y)
+	 self.y = y
+      end,
+      x = 60,
+      y = 60
+   }
+
+   -- test tweening for multi-value getter/setter
+   multivar_setget = {
+      getP = function(self)
+	 return self.x, self.y
+      end,
+      setP = function(self, x, y)
+	 self.x = x
+	 self.y = y
+      end,
+      x = 80,
+      y = 80
+   }
+
+   -- test tweening for table-best getter/setter
+   table_setget = {
+      getP = function(self)
+	 return self.posn
+      end,
+      setP = function(self, posn)
+	 self.posn.x = posn.x
+	 self.posn.y = posn.y
+      end,
+      posn={x=100, y=100}
+   }
+
+   -- test tweening setget for array-like tables
+   array_setget = {
+      getP = function(self)
+	 return self.posn
+      end,
+      setP = function(self, posn)
+	 self.posn=posn
+      end,
+      posn = {120, 120}
+   }
+   pt = 600
+   t = 3
+   globalt = 0
+   --test direct tweening of userdata
+   Timer.tween(t, love.graphics, {Color={0, 0, 0}})
+   
+   Timer.tween(t, basic, {x=pt, y=pt})
+   Timer.tween(t, inner_table, {posn={x=pt, y=pt}})
+   Timer.tween(t, array_like, {pt, pt})
+   Timer.func_tween(t, univar_setget, {X=pt, Y=pt}, nil, nil, {
+   			     X={univar_setget.setX, univar_setget.getX},
+   			     Y={univar_setget.setY, univar_setget.getY}})
+   Timer.tween(t, multivar_setget, {P={pt, pt}})
+   Timer.tween(t, table_setget, {P={{x=pt, y=pt}}})
+   Timer.tween(t, array_setget, {P={{pt, pt}}})
+
+end
+--TODO ??
+function love.draw()
+   love.graphics.circle('fill', basic.x, basic.y,10)
+   love.graphics.circle('fill', inner_table.posn.x, inner_table.posn.y, 10)
+   love.graphics.circle('fill', array_like[1], array_like[2], 10)
+   love.graphics.circle('fill', univar_setget:getX(), univar_setget:getY(), 10)
+   toshow = {multivar_setget:getP()}
+   toshow[#toshow+1] = 10
+   love.graphics.circle('fill', unpack(toshow))
+   table_toshow = table_setget:getP()
+   love.graphics.circle('fill', table_toshow.x, table_toshow.y, 10)
+   array_toshow = array_setget:getP()
+   array_toshow[#array_toshow+1]=10
+   love.graphics.circle('fill', unpack(array_toshow))
+end
+
+function love.update(dt)
+   Timer.update(dt)
+   globalt = globalt + dt
+
+end

--- a/tests/main.lua
+++ b/tests/main.lua
@@ -1,4 +1,4 @@
-Timer = require("../timer")
+Timer = require("timer")
 
 
 function love.load()

--- a/timer.lua
+++ b/timer.lua
@@ -90,7 +90,7 @@ function Timer:cancel(handle)
 end
 
 function Timer:clear()
-	self.functions = {}
+	 self.functions = {}
 end
 
 function Timer:script(f)
@@ -101,99 +101,159 @@ function Timer:script(f)
 	end)
 end
 
-Timer.tween = setmetatable({
-	-- helper functions
-	out = function(f) -- 'rotates' a function
-		return function(s, ...) return 1 - f(1-s, ...) end
-	end,
-	chain = function(f1, f2) -- concatenates two functions
-		return function(s, ...) return (s < .5 and f1(2*s, ...) or 1 + f2(2*s-1, ...)) * .5 end
-	end,
+local function func_tween(tween, self, len, subject, target, method, after,
+	   setters_and_getters, ...)
+   -- recursively collects fields that are defined in both subject and target into a flat list
+   -- re-use of ref is confusing
+   local to_func_tween = {}
+   local function set_and_get(subject, k, v)
+      setters_and_getters = setters_and_getters or {}
 
-	-- useful tweening functions
-	linear = function(s) return s end,
-	quad   = function(s) return s*s end,
-	cubic  = function(s) return s*s*s end,
-	quart  = function(s) return s*s*s*s end,
-	quint  = function(s) return s*s*s*s*s end,
-	sine   = function(s) return 1-math.cos(s*math.pi/2) end,
-	expo   = function(s) return 2^(10*(s-1)) end,
-	circ   = function(s) return 1 - math.sqrt(1-s*s) end,
+      local setter, getter
+      if setters_and_getters[k] then
+	 setter, getter = unpack(setters_and_getters[k])
+      else
+	 setter = subject['set'..k]
+	 getter = subject['get'..k]
+      end
 
-	back = function(s,bounciness)
-		bounciness = bounciness or 1.70158
-		return s*s*((bounciness+1)*s - bounciness)
-	end,
+      assert(setter and getter,
+	     "key's value in subject is nil with no set/getter")
 
-	bounce = function(s) -- magic numbers ahead
-		local a,b = 7.5625, 1/2.75
-		return math.min(a*s^2, a*(s-1.5*b)^2 + .75, a*(s-2.25*b)^2 + .9375, a*(s-2.625*b)^2 + .984375)
-	end,
+      if to_func_tween[subject] == nil then
+	 to_func_tween[subject] = {}
+      end
 
-	elastic = function(s, amp, period)
-		amp, period = amp and math.max(1, amp) or 1, period or .3
-		return (-amp * math.sin(2*math.pi/period * (s-1) - math.asin(1/amp))) * 2^(10*(s-1))
-	end,
-}, {
+      ref = {getter(subject)}
+      to_func_tween[subject][k] = {ref, setter}
+      if type(v) == 'number' then
+	 v = {v}
+      end
+      return ref, v
+   end
 
--- register new tween
-__call = function(tween, self, len, subject, target, method, after, ...)
-	-- recursively collects fields that are defined in both subject and target into a flat list
-	local function tween_collect_payload(subject, target, out)
-		for k,v in pairs(target) do
-			local ref = subject[k]
-			assert(type(v) == type(ref), 'Type mismatch in field "'..k..'".')
-			if type(v) == 'table' then
-				tween_collect_payload(ref, v, out)
-			else
-				local ok, delta = pcall(function() return (v-ref)*1 end)
-				assert(ok, 'Field "'..k..'" does not support arithmetic operations')
-				out[#out+1] = {subject, k, delta}
-			end
-		end
-		return out
-	end
+   local function tween_collect_payload(subject, target, out)
+      for k,v in pairs(target) do
 
-	method = tween[method or 'linear'] -- see __index
-	local payload, t, args = tween_collect_payload(subject, target, {}), 0, {...}
+	 -- this might not be the smoothest way to do this
+	 local ref = subject[k]
+	 if ref == nil then
+	    ref, v = set_and_get(subject, k, v)
+	 end
 
-	local last_s = 0
-	return self:during(len, function(dt)
-		t = t + dt
-		local s = method(math.min(1, t/len), unpack(args))
-		local ds = s - last_s
-		last_s = s
-		for _, info in ipairs(payload) do
-			local ref, key, delta = unpack(info)
-			ref[key] = ref[key] + delta * ds
-		end
-	end, after)
-end,
+	 assert(type(v) == type(ref), 'Type mismatch in field "'..k..'". '
+		   ..type(v)..' vs '.. type(ref))
+	 if type(v) == 'table' then
+	    tween_collect_payload(ref, v, out)
+	 else
+	    local ok, delta = pcall(function() return (v-ref)*1 end)
+	    assert(ok, 'Field "'..k..'" does not support arithmetic operations')
+	    out[#out+1] = {subject, k, delta}
+	 end
+      end
+      return out
+   end
 
--- fetches function and generated compositions for method `key`
-__index = function(tweens, key)
-	if type(key) == 'function' then return key end
+   method = tween[method or 'linear'] -- see __index
+   local payload, t, args = tween_collect_payload(subject, target, {}), 0, {...}
 
-	assert(type(key) == 'string', 'Method must be function or string.')
-	if rawget(tweens, key) then return rawget(tweens, key) end
+   local last_s = 0
+   return self:during(len, function(dt)
+      t = t + dt
+      local s = method(math.min(1, t/len), unpack(args))
+      local ds = s - last_s
+      last_s = s
+      for _, info in ipairs(payload) do
+	 local ref, key, delta = unpack(info)
+	 ref[key] = ref[key] + delta * ds
+      end
+      for ref, t in pairs(to_func_tween) do
+	 for key, value in pairs(t) do
+	    local setter_args, setter = unpack(value)
+	    if not pcall(function() setter(ref, unpack(setter_args)) end) then
+	       setter(unpack(setter_args))
+	    end
+	 end
+      end
+   end, after)
+end
 
-	local function construct(pattern, f)
-		local method = rawget(tweens, key:match(pattern))
-		if method then return f(method) end
-		return nil
-	end
+local function plain_tween(tween, self, len, subject, target, method, after, ...)
+   return func_tween(tween, self, len, subject, target, method, after, nil, ...)
+end
 
-	local out, chain = rawget(tweens,'out'), rawget(tweens,'chain')
-	return construct('^in%-([^-]+)$', function(...) return ... end)
+
+local function def_tween(func)
+   return setmetatable(
+      {
+	 -- helper functions
+	 out = function(f) -- 'rotates' a function
+	    return function(s, ...) return 1 - f(1-s, ...) end
+	 end,
+	 chain = function(f1, f2) -- concatenates two functions
+	    return function(s, ...) return (s < .5 and f1(2*s, ...) or 1 + f2(2*s-1, ...)) * .5 end
+	 end,
+
+	 -- useful tweening functions
+	 linear = function(s) return s end,
+	 quad   = function(s) return s*s end,
+	 cubic  = function(s) return s*s*s end,
+	 quart  = function(s) return s*s*s*s end,
+	 quint  = function(s) return s*s*s*s*s end,
+	 sine   = function(s) return 1-math.cos(s*math.pi/2) end,
+	 expo   = function(s) return 2^(10*(s-1)) end,
+	 circ   = function(s) return 1 - math.sqrt(1-s*s) end,
+
+	 back = function(s,bounciness)
+	    bounciness = bounciness or 1.70158
+	    return s*s*((bounciness+1)*s - bounciness)
+	 end,
+
+	 bounce = function(s) -- magic numbers ahead
+	    local a,b = 7.5625, 1/2.75
+	    return math.min(a*s^2, a*(s-1.5*b)^2 + .75, a*(s-2.25*b)^2 + .9375, a*(s-2.625*b)^2 + .984375)
+	 end,
+
+	 elastic = function(s, amp, period)
+	    amp, period = amp and math.max(1, amp) or 1, period or .3
+	    return (-amp * math.sin(2*math.pi/period * (s-1) - math.asin(1/amp))) * 2^(10*(s-1))
+	 end,
+
+
+      }, {
+
+	 -- register new tween
+	 __call = func,
+
+	 -- fetches function and generated compositions for method `key`
+	 __index = function(tweens, key)
+	    if type(key) == 'function' then return key end
+
+	    assert(type(key) == 'string', 'Method must be function or string.')
+	    if rawget(tweens, key) then return rawget(tweens, key) end
+
+	    local function construct(pattern, f)
+	       local method = rawget(tweens, key:match(pattern))
+	       if method then return f(method) end
+	       return nil
+	    end
+
+	    local out, chain = rawget(tweens,'out'), rawget(tweens,'chain')
+	    return construct('^in%-([^-]+)$', function(...) return ... end)
 	       or construct('^out%-([^-]+)$', out)
-	       or construct('^in%-out%-([^-]+)$', function(f) return chain(f, out(f)) end)
-	       or construct('^out%-in%-([^-]+)$', function(f) return chain(out(f), f) end)
-	       or error('Unknown interpolation method: ' .. key)
-end})
+	    or construct('^in%-out%-([^-]+)$', function(f) return chain(f, out(f)) end)
+	    or construct('^out%-in%-([^-]+)$', function(f) return chain(out(f), f) end)
+dd	       or error('Unknown interpolation method: ' .. key)
+   end})
+end
+
+
+Timer.tween = def_tween(plain_tween)
+Timer.func_tween = def_tween(func_tween)
 
 -- Timer instancing
 function Timer.new()
-	return setmetatable({functions = {}, tween = Timer.tween}, Timer)
+   return setmetatable({functions = {}, tween = Timer.tween}, Timer)
 end
 
 -- default instance
@@ -202,14 +262,14 @@ local default = Timer.new()
 -- module forwards calls to default instance
 local module = {}
 for k in pairs(Timer) do
-	if k ~= "__index" then
-		module[k] = function(...) return default[k](default, ...) end
-	end
+   if k ~= "__index" then
+      module[k] = function(...) return default[k](default, ...) end
+   end
 end
 module.tween = setmetatable({}, {
-	__index = Timer.tween,
-	__newindex = function(k,v) Timer.tween[k] = v end,
-	__call = function(t, ...) return default:tween(...) end,
+   __index = Timer.tween,
+   __newindex = function(k,v) Timer.tween[k] = v end,
+   __call = function(t, ...) return default:tween(...) end,
 })
 
 return setmetatable(module, {__call = Timer.new})

--- a/timer.lua
+++ b/timer.lua
@@ -243,7 +243,7 @@ local function def_tween(func)
 	       or construct('^out%-([^-]+)$', out)
 	    or construct('^in%-out%-([^-]+)$', function(f) return chain(f, out(f)) end)
 	    or construct('^out%-in%-([^-]+)$', function(f) return chain(out(f), f) end)
-dd	       or error('Unknown interpolation method: ' .. key)
+	       or error('Unknown interpolation method: ' .. key)
    end})
 end
 

--- a/timer.lua
+++ b/timer.lua
@@ -116,7 +116,6 @@ local function func_tween(tween, self, len, subject, target, method, after,
 	 setter = subject['set'..k]
 	 getter = subject['get'..k]
       end
-
       assert(setter and getter,
 	     "key's value in subject is nil with no set/getter")
 
@@ -126,7 +125,7 @@ local function func_tween(tween, self, len, subject, target, method, after,
 
       ref = {getter(subject)}
       to_func_tween[subject][k] = {ref, setter}
-      if type(v) == 'number' then
+      if type(v) == 'number' or #ref == 1 then
 	 v = {v}
       end
       return ref, v
@@ -140,7 +139,6 @@ local function func_tween(tween, self, len, subject, target, method, after,
 	 if ref == nil then
 	    ref, v = set_and_get(subject, k, v)
 	 end
-
 	 assert(type(v) == type(ref), 'Type mismatch in field "'..k..'". '
 		   ..type(v)..' vs '.. type(ref))
 	 if type(v) == 'table' then


### PR DESCRIPTION
Hi,
I wanted to use tweening for love.physics objects, sound, color, etc. but of course simple assignment doesn't work for these methods without some awkward __index __newindex metamethods.
So I decided to see if I could improve hump.timer's tweening
Since supplying getters and setters for a value involves another argument I implemeted this as a separate callable Timer.func_tween, to avoid breaking compatibility of Timer.tween with older code.

func_tween allows easy tweening of variables accessed by setters/getters, including those inside love2d userdata. Those are particularly easy in fact, as you can just supply the remainder of the func name after get/set (e.g. Color for setColor and getColor) and the getters and setters will be inferred.

Thanks in advance for any feedback.