### PR TITLE
added init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,16 @@
+local dir = (...) .. '.'
+assert(not dir:match('%.init%.$'), "Invalid require path `"..(...).."' (remove the `.init').")
+
+local function get(mod_name)
+	return require(dir..mod_name)
+end
+
+return {
+	camera       = get("camera"),
+	class        = get("class"),
+	gamestate    = get("gamestate"),
+	signal       = get("signal"),
+	timer        = get("timer"),
+	vector_light = get("vector-light"),
+	vector       = get("vector")
+}


### PR DESCRIPTION
Added `init.lua` to quickly load all hump modules into a single table without manually importing each at a time.
Module can be imported with `hump = require("lib/hump")` and each module is accessible via for example `hump.camera` etc.

Old way of importing modules still works `camera = require("lib/hump/camera")`!